### PR TITLE
Update vagrant box to System Tests in CMS core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
-# Joomla! Vagrant Testing box
+# Joomla Vagrant Testing box
 
-This vagrant box allows you to easily run and create tests for the Joomla! CMS.
+This vagrant box allows you to easily run and create tests for the Joomla CMS.
 
 [![ScreenShot](http://img.youtube.com/vi/Y7QSYELLEF8/0.jpg)](https://www.youtube.com/watch?v=Y7QSYELLEF8)
 
-For more details on tests see [https://github.com/joomla-projects/gsoc16_browser-automated-tests](https://github.com/joomla-projects/gsoc16_browser-automated-tests)
+For more details on tests see [https://github.com/joomla/joomla-cms/tree/staging/tests/codeception](https://github.com/joomla/joomla-cms/tree/staging/tests/codeception)
 
 ### Specs:
 
 * Ubuntu 14.04 LTS
 * Fluxbox
-* Apache 2
-* PHP 7 (Ondrej)
-* Joomla gsoc16_browser-automated-tests repository
-* MySQL
+* Apache 2.4
+* PHP 7 
+* Joomla repository
+* MySQL 5.7
+* OpenJDK 8 (needed for selenium)
+* Joomla staging
+* Firefox & Chrome
 
 ### Installation
 
@@ -23,7 +26,7 @@ Install Vagrant (available for all major operating systems) and navigate with th
 vagrant up
 ```
 
-The initial setup is, depending on your internet connection, going to take some time. It's normal for VirtualBox to show up, please don't login and wait for the installation to finish.
+The initial setup is, depending on your internet connection speed, going to take some time. It's normal for VirtualBox to show up, please don't login and wait for the installation to finish.
 
 ### Update
 Updating to the latest version

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ VAGRANTFILE_API_VERSION = "2"
     hostname = "joomlatesting.box"
     locale = "en_GB.UTF-8"
 
-    # use the default ubuntu 64bit image
+    # use the ubuntu 64bit image
     config.vm.box = "ubuntu/trusty64"
 
     config.vm.provider "virtualbox" do |v|

--- a/joomla/config/000-default.conf
+++ b/joomla/config/000-default.conf
@@ -1,31 +1,9 @@
 <VirtualHost *:80>
-	# The ServerName directive sets the request scheme, hostname and port that
-	# the server uses to identify itself. This is used when creating
-	# redirection URLs. In the context of virtual hosts, the ServerName
-	# specifies what hostname must appear in the request's Host: header to
-	# match this virtual host. For the default virtual host (this file) this
-	# value is not decisive as it is used as a last resort host regardless.
-	# However, you must set it for any further virtual host explicitly.
-	#ServerName joomla.org
-
-	ServerAdmin vagrant@joomla.org
+	ServerAdmin testing@joomla.org
 	DocumentRoot /joomla/install
-
-	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-	# error, crit, alert, emerg.
-	# It is also possible to configure the loglevel for particular
-	# modules, e.g.
-	#LogLevel info ssl:warn
 
 	ErrorLog ${APACHE_LOG_DIR}/error.log
 	CustomLog ${APACHE_LOG_DIR}/access.log combined
-
-	# For most configuration files from conf-available/, which are
-	# enabled or disabled at a global level, it is possible to
-	# include a line for only one particular virtual host. For example the
-	# following line enables the CGI configuration for this host only
-	# after it has been globally disabled with "a2disconf".
-	#Include conf-available/serve-cgi-bin.conf
 </VirtualHost>
 
 <Directory /joomla/install>

--- a/vagrant-bootstrap.sh
+++ b/vagrant-bootstrap.sh
@@ -1,29 +1,31 @@
 # Setting up Vagrant
-# Update packages
+# Add ondrej for PHP 7.0
 LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
+LC_ALL=C.UTF-8 add-apt-repository ppa:openjdk-r/ppa
 
+JOOMLA_INSTALLATION=/joomla/install
+
+# Update packages
 apt-get -y update
 
 export DEBIAN_FRONTEND='noninteractive'
 
-# Install git
-apt-get -y install git wget unzip
+# Install dependencies
+apt-get install -y wget unzip git fluxbox openjdk-8-jre xvfb \
+	dbus libxss1 libappindicator1 libindicator7 xdg-utils libasound2 libqt4-dbus \
+    libqt4-network libqtcore4 libqtgui4 libpython2.7 libqt4-xml libaudio2 fontconfig vim xorg rungetty gnome-terminal xterm firefox
 
-apt-get install -y mysql-server apache2 wget unzip git fluxbox openjdk-7-jre xvfb \
-	dbus libasound2 libqt4-dbus libqt4-network libqtcore4 libqtgui4 libpython2.7 libqt4-xml libaudio2 fontconfig vim xorg rungetty gnome-terminal xterm firefox
+# AMP Stack
+apt-get install -y mysql-server apache2 php7.0 php7.0-mysql php7.0-mcrypt php7.0-curl php7.0-gd php7.0-opcache php7.0-cli \
+ libapache2-mod-php7.0 php-xdebug php7.0-xml php7.0-mbstring php7.0-zip
 
-# PHP 7
-apt-get install -y php7.0 php7.0-mysql php7.0-mcrypt php7.0-curl php7.0-gd php7.0-opcache php7.0-cli libapache2-mod-php7.0 php7.0-xdebug php7.0-xml php7.0-mbstring
+wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+dpkg -i google-chrome*.deb
 
-# Firefox 43 (Working with Selenium)
-wget –-quiet http://packages.linuxmint.com/pool/import/f/firefox/firefox_43.0~linuxmint1%2bbetsy_amd64.deb
-
-apt-get remove -y firefox
-
-dpkg -i --force-all firefox_43.0~linuxmint1+betsy_amd64.deb
+apt-get install -f -y
 
 # clean up
-apt-get clean
+apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Make sure the permissions are alright.
 chmod 700 ~/.ssh
@@ -46,7 +48,7 @@ adduser joomla sudo
 
 # automount vbox share, we can't use auto here..
 echo "" >> /etc/fstab
-echo "joomla /joomla  vboxsf  noauto,rw,uid=1002,gid=1002  0 0" >> /etc/fstab
+echo "joomla /joomla  vboxsf noauto,rw,uid=1002,gid=1002 0 0" >> /etc/fstab
 
 echo '#!/bin/sh -e' > /etc/rc.local
 echo "mount /joomla" >> /etc/rc.local
@@ -78,16 +80,26 @@ cp /joomla/config/menu /home/joomla/.fluxbox/menu
 
 chown -R joomla:joomla /home/joomla
 
-# Get joomla testing repository
-git clone --depth 1 https://github.com/joomla-projects/gsoc16_browser-automated-tests.git /joomla/install
+# Delete possible old installation
+if [ -d "$JOOMLA_INSTALLATION" ]; then
+    rm -rf "$JOOMLA_INSTALLATION"
+fi
 
-cd /joomla/install/tests/codeception
+# Get joomla repository
+git clone --depth 1 https://github.com/joomla/joomla-cms "$JOOMLA_INSTALLATION"
+
+cd "$JOOMLA_INSTALLATION/tests/codeception"
+
+cp acceptance.suite.dist.yml acceptance.suite.yml
 
 composer install
 
+chown -R joomla:joomla /joomla
+
 echo "---------------------"
 echo "Rebooting into your new system"
-echo "Everything setup - Thank you for helping Joomla!"
+echo "https://github.com/joomla-projects/vagrant-joomla-testing"
+echo "Everything setup - Thank you for testing Joomla!"
 
 # Restart into system
 reboot


### PR DESCRIPTION
Updating the vagrant box for the merged system tests in core and other minor improvements.

https://github.com/joomla/joomla-cms/pull/16743

Changelog:

* Added Google Chrome
* Switch to joomla/joomla-cms repo
* Automatically install all dependencies
* Switch to OpenJDK 8
* Take care of acceptance.suite.yml

## Testing instructions

Follow the README.md

